### PR TITLE
Fix @src as list

### DIFF
--- a/pymediaroom/notify.py
+++ b/pymediaroom/notify.py
@@ -4,6 +4,7 @@ import asyncio
 import socket
 import logging
 import xmltodict
+import collections
 
 from .error import PyMediaroomError
 

--- a/pymediaroom/notify.py
+++ b/pymediaroom/notify.py
@@ -59,7 +59,9 @@ class MediaroomNotify(object):
     def tune(self):
         """XML node representing tune."""
         if self._node.get('activities'):
-            return self._node['activities'].get('tune')
+            tune = self._node['activities'].get('tune')
+            if
+            return None if not tune else tune[0]
         return None
 
     @property

--- a/pymediaroom/notify.py
+++ b/pymediaroom/notify.py
@@ -60,8 +60,11 @@ class MediaroomNotify(object):
         """XML node representing tune."""
         if self._node.get('activities'):
             tune = self._node['activities'].get('tune')
-            if
-            return None if not tune else tune[0]
+            if type(tune) is collections.OrderedDict:
+                return tune
+            elif type(tune) is list:
+                return tune[0]
+            return tune
         return None
 
     @property


### PR DESCRIPTION
In my case (Cisco, with Vodafone firmware), `@src` is always (i.e., so far, after a few hours of testing) either a `list` containing an `OrderedDict` (which caused this to blow up on the notification callback) or `None`.